### PR TITLE
Add `specs` to horizontal and vertical tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ Tile specs can also be accessed directly via `children` snippet
 ```svelte
 <HTile width="400px" height="300px" innerPadding="10px" outerPadding="5px">
   <Tile width="180px">
-    {#snippet children({ specs: { width, height }})}
-      <MyComponent1 {width} {height} />
+    {#snippet children({ specs })}
+      <MyComponent1 width={specs?.width} height={specs?.height} />
     {/snippet}
   </Tile>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilez",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Torsten Sprenger <mail@spren9er.de>",
   "description": "Generic layout engine for Svelte components",
   "keywords": [

--- a/src/lib/components/HTile.svelte
+++ b/src/lib/components/HTile.svelte
@@ -10,6 +10,7 @@
     TypeTilePropsElement,
     TypeTilePropsWrapper,
   } from '$lib/types/tileProps.type';
+  import type { TileSpecs } from '$lib/entities/tileSpecs';
 
   import Tile from './Tile.svelte';
 
@@ -22,9 +23,10 @@
     vAlign?: TypeTilePropsVAlign | undefined;
     type?: TypeTilePropsType | undefined;
     mode?: TypeTilePropsMode | undefined;
+    specs?: TileSpecs | undefined;
     element?: TypeTilePropsElement | undefined;
     wrapper?: TypeTilePropsWrapper | undefined;
-    children?: Snippet<[unknown]>;
+    children?: Snippet<[{ specs?: TileSpecs; element?: TypeTilePropsElement }]>;
   }
 
   let {
@@ -36,6 +38,7 @@
     vAlign = undefined,
     type = undefined,
     mode = undefined,
+    specs = $bindable(undefined),
     element = $bindable(undefined),
     wrapper = $bindable(undefined),
     children,
@@ -52,8 +55,9 @@
   {vAlign}
   {type}
   {mode}
-  bind:wrapper
+  bind:specs
   bind:element
+  bind:wrapper
 >
-  {@render children?.({ element })}
+  {@render children?.({ specs, element })}
 </Tile>

--- a/src/lib/components/Tile.svelte
+++ b/src/lib/components/Tile.svelte
@@ -36,7 +36,7 @@
     specs?: TileSpecs | undefined;
     element?: TypeTilePropsElement | undefined;
     wrapper?: TypeTilePropsWrapper | undefined;
-    children?: Snippet<[{ specs: TileSpecs; element?: TypeTilePropsElement }]>;
+    children?: Snippet<[{ specs?: TileSpecs; element?: TypeTilePropsElement }]>;
   }
 
   let {
@@ -119,9 +119,6 @@
 <TileWrapper node={$node} bind:wrapper bind:containerWidth bind:containerHeight>
   {@const SvelteComponent = componentFor($node)}
   <SvelteComponent node={$node} bind:element>
-    {@render children?.({
-      specs: $node.specs,
-      element,
-    })}
+    {@render children?.({ specs, element })}
   </SvelteComponent>
 </TileWrapper>

--- a/src/lib/components/VTile.svelte
+++ b/src/lib/components/VTile.svelte
@@ -10,6 +10,7 @@
     TypeTilePropsElement,
     TypeTilePropsWrapper,
   } from '$lib/types/tileProps.type';
+  import type { TileSpecs } from '$lib/entities/tileSpecs';
 
   import Tile from './Tile.svelte';
 
@@ -22,9 +23,10 @@
     vAlign?: TypeTilePropsVAlign | undefined;
     type?: TypeTilePropsType | undefined;
     mode?: TypeTilePropsMode | undefined;
+    specs?: TileSpecs | undefined;
     element?: TypeTilePropsElement | undefined;
     wrapper?: TypeTilePropsWrapper | undefined;
-    children?: Snippet<[unknown]>;
+    children?: Snippet<[{ specs?: TileSpecs; element?: TypeTilePropsElement }]>;
   }
 
   let {
@@ -36,6 +38,7 @@
     vAlign = undefined,
     type = undefined,
     mode = undefined,
+    specs = $bindable(undefined),
     element = $bindable(undefined),
     wrapper = $bindable(undefined),
     children,
@@ -52,8 +55,9 @@
   {vAlign}
   {type}
   {mode}
-  bind:wrapper
+  bind:specs
   bind:element
+  bind:wrapper
 >
-  {@render children?.({ element })}
+  {@render children?.({ specs, element })}
 </Tile>


### PR DESCRIPTION
## Why are the changes necessary?

In recent version we added `specs` to `Tile` component, but missed to add it `HTile` and `VTile` components.

## What does this pull request cover?

Add `specs` to `HTile` and `VTile` component.